### PR TITLE
Restore hip_free call (fix crash on hip)

### DIFF
--- a/devices/hip/hip_external_buffer.cpp
+++ b/devices/hip/hip_external_buffer.cpp
@@ -83,7 +83,7 @@ OIDN_NAMESPACE_BEGIN
 
   HIPExternalBuffer::~HIPExternalBuffer()
   {
-    //hipFree(ptr); // FIXME: disabled due to a bug in HIP (https://github.com/ROCm-Developer-Tools/hip-tests/blob/develop/catch/unit/vulkan_interop/hipExternalMemoryGetMappedBuffer.cc#L65)
+    hipFree(ptr);
     hipDestroyExternalMemory(extMem);
   }
 


### PR DESCRIPTION
Fix crash with hip backend. HIP SDK version ROCm 5.7.1