### PR TITLE
Update composable_kernel to rocm-6.3.1 tag

### DIFF
--- a/devices/hip/CMakeLists.txt
+++ b/devices/hip/CMakeLists.txt
@@ -53,6 +53,11 @@ set_target_properties(OpenImageDenoise_device_hip PROPERTIES
   CXX_STANDARD 17
 )
 
+configure_file(
+  "${OIDN_ROOT_SOURCE_DIR}/external/composable_kernel/include/ck/config.h.in"
+  "${OIDN_ROOT_SOURCE_DIR}/external/composable_kernel/include/ck/config.h"
+)
+
 target_include_directories(OpenImageDenoise_device_hip
   PRIVATE
     "${OIDN_ROOT_SOURCE_DIR}/external/composable_kernel/include"

--- a/devices/hip/ck_conv_dl.cpp
+++ b/devices/hip/ck_conv_dl.cpp
@@ -3,7 +3,7 @@
 
 #include "hip_conv.h"
 #include "ck_conv.h"
-#include "ck/tensor_operation/gpu/device/device_grouped_conv_fwd_dl_multiple_d_nhwc_kyxc_nhwk.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_dl_multiple_d_nhwc_kyxc_nhwk.hpp"
 
 OIDN_NAMESPACE_BEGIN
 

--- a/devices/hip/ck_conv_wmma.cpp
+++ b/devices/hip/ck_conv_wmma.cpp
@@ -48,41 +48,42 @@ OIDN_NAMESPACE_BEGIN
         OutLayout,               // ELayout
         InDataType,              // ADataType
         WeiDataType,             // BDataType
-        ck::Tuple<BiasDataType>, // DsDataType
-        OutDataType,             // EDataType
         AccDataType,             // AccDataType
         CShuffleDataType,        // CShuffleDataType
+        ck::Tuple<BiasDataType>, // DsDataType
+        OutDataType,             // EDataType
         InElementOp,             // AElementwiseOperation
         WeiElementOp,            // BElementwiseOperation
         OutElementOp,            // CDEElementwiseOperation
         ConvSpec,                // ConvForwardSpecialization
         GemmSpec,                // GemmSpecialization
-        256,                     // BlockSize
-        128,                     // MPerBlock
-        64,                      // NPerBlock
-        4,                       // K0PerBlock
+        1,                       // PrefetchStage
+        64,                      // BlockSize
+        64,                      // MPerBlock
+        32,                      // NPerBlock
+        32,                      // KPerBlock
         8,                       // K1
         16,                      // MPerWMMA
         16,                      // NPerWMMA
-        4,                       // MRepeat
-        1,                       // NRepeat
-        S<4, 64, 1>,             // ABlockTransferThreadClusterLengths_AK0_M_AK1
+        2,                       // MRepeat
+        2,                       // NRepeat
+        S<4, 16, 1>,             // ABlockTransferThreadClusterLengths_AK0_M_AK1
         S<1, 0, 2>,              // ABlockTransferThreadClusterArrangeOrder
         S<1, 0, 2>,              // ABlockTransferSrcAccessOrder
         2,                       // ABlockTransferSrcVectorDim
         8,                       // ABlockTransferSrcScalarPerVector
-        8,                       // ABlockTransferDstScalarPerVector_AK1
-        true,                    // ABlockLdsExtraM
-        S<4, 64, 1>,             // BBlockTransferThreadClusterLengths_BK0_N_BK1
+        8,                       // ABlockTransferDstScalarPerVector_K1
+        1,                       // ABlockLdsExtraM
+        S<4, 16, 1>,             // BBlockTransferThreadClusterLengths_BK0_N_K1
         S<1, 0, 2>,              // BBlockTransferThreadClusterArrangeOrder
         S<1, 0, 2>,              // BBlockTransferSrcAccessOrder
         2,                       // BBlockTransferSrcVectorDim
         8,                       // BBlockTransferSrcScalarPerVector
-        8,                       // BBlockTransferDstScalarPerVector_BK1
-        true,                    // BBlockLdsExtraN
-        1,                       // CShuffleMRepeatPerShuffle
-        1,                       // CShuffleNRepeatPerShuffle
-        S<1, 32, 1, 8>,          // CDEShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
+        8,                       // BBlockTransferDstScalarPerVector_K1
+        1,                       // BBlockLdsExtraN
+        1,                       // CShuffleMXdlPerWavePerShuffle
+        1,                       // CShuffleNXdlPerWavePerShuffle
+        S<1, 32, 1, 2>,          // CDEShuffleBlockTransferClusterLengths_MBlock_MWaveMPerXdl_NBlock_NWaveNPerXdl
         8                        // CDEShuffleBlockTransferScalarPerVector_NPerBlock
       >;
 


### PR DESCRIPTION
This fixes compilation with recent versions of Clang (Clang 19 specifically).

Additionally, as `DeviceGroupedConvFwdMultipleD_Wmma_CShuffle` API was changed, new wmma configuration provides 15% better performance on 7900XTX GPU (gfx1100).

Closes #250