### PR TITLE
CI ARM

### DIFF
--- a/.github/workflows/external.ci.yml
+++ b/.github/workflows/external.ci.yml
@@ -67,6 +67,8 @@ jobs:
         name: build-cpu-rocky-8
 
     - name: Test
+      # Adding execution bit to binaries is needed since upload/download GHA is using zip compression
+      # and it can't preserve files permissions - https://github.com/actions/upload-artifact/issues/38
       run: |
         chmod +x ./bin/*
         ./bin/oidnTest
@@ -124,6 +126,8 @@ jobs:
         name: build-cpu-ubuntu-2204
 
     - name: Test
+      # Adding execution bit to binaries is needed since upload/download GHA is using zip compression
+      # and it can't preserve files permissions - https://github.com/actions/upload-artifact/issues/38
       run: |
         chmod +x ./bin/*
         ./bin/oidnTest
@@ -145,9 +149,9 @@ jobs:
         mkdir /tmp/deps
         cd /tmp/deps
 
-        wget https://github.com/ispc/ispc/releases/download/v1.24.0/ispc-v1.24.0-linux.tar.gz
-        tar -xvf ispc-v1.24.0-linux.tar.gz
-        echo "PATH=$PATH:`pwd`/ispc-v1.24.0-linux/bin" >> $GITHUB_ENV
+        wget https://github.com/ispc/ispc/releases/download/v1.24.0/ispc-v1.24.0-linux.aarch64.tar.gz
+        tar -xvf ispc-v1.24.0-linux.aarch64.tar.gz
+        echo "PATH=$PATH:`pwd`/ispc-v1.24.0-linux.aarch64/bin" >> $GITHUB_ENV
 
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -184,9 +188,9 @@ jobs:
         mkdir /tmp/deps
         cd /tmp/deps
 
-        wget https://github.com/ispc/ispc/releases/download/v1.24.0/ispc-v1.24.0-linux.tar.gz
-        tar -xvf ispc-v1.24.0-linux.tar.gz
-        echo "PATH=$PATH:`pwd`/ispc-v1.24.0-linux/bin" >> $GITHUB_ENV
+        wget https://github.com/ispc/ispc/releases/download/v1.24.0/ispc-v1.24.0-linux.aarch64.tar.gz
+        tar -xvf ispc-v1.24.0-linux.aarch64.tar.gz
+        echo "PATH=$PATH:`pwd`/ispc-v1.24.0-linux.aarch64/bin" >> $GITHUB_ENV
 
     - name: Checkout Repository
       uses: actions/checkout@v4

--- a/.github/workflows/external.ci.yml
+++ b/.github/workflows/external.ci.yml
@@ -169,7 +169,7 @@ jobs:
         path: build/install
 
   build-cpu-ubuntu-2204-arm:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     container:
       image: arm64v8/ubuntu:22.04
 

--- a/.github/workflows/external.ci.yml
+++ b/.github/workflows/external.ci.yml
@@ -171,7 +171,27 @@ jobs:
       with:
         name: build-cpu-rocky-8-arm
         path: build/install
+  
+  test-cpu-rocky-8-arm:
+    needs: build-cpu-rocky-8-arm
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: arm64v8/rockylinux:8
 
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-cpu-rocky-8-arm
+
+      - name: Test
+        # Adding execution bit to binaries is needed since upload/download GHA is using zip compression
+        # and it can't preserve files permissions - https://github.com/actions/upload-artifact/issues/38
+        run: |
+          chmod +x ./bin/*
+          ./bin/oidnTest
+          ./bin/oidnBenchmark -v 1
+          
   build-cpu-ubuntu-2204-arm:
     runs-on: ubuntu-24.04-arm
     container:
@@ -210,3 +230,24 @@ jobs:
       with:
         name: build-cpu-ubuntu-2204-arm
         path: build/install
+        
+  test-cpu-ubuntu-2204-arm:
+    needs: build-cpu-ubuntu-2204-arm
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: arm64v8/ubuntu:22.04
+
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-cpu-ubuntu-2204-arm
+
+      - name: Test
+        # Adding execution bit to binaries is needed since upload/download GHA is using zip compression
+        # and it can't preserve files permissions - https://github.com/actions/upload-artifact/issues/38
+        run: |
+          chmod +x ./bin/*
+          ./bin/oidnTest
+          ./bin/oidnBenchmark -v 1
+          

--- a/.github/workflows/external.ci.yml
+++ b/.github/workflows/external.ci.yml
@@ -54,7 +54,6 @@ jobs:
         name: build-cpu-rocky-8
         path: build/install
 
-
   test-cpu-rocky-8:
     needs: build-cpu-rocky-8
     runs-on: ubuntu-latest
@@ -69,13 +68,9 @@ jobs:
 
     - name: Test
       run: |
-        # Adding execution bit to binaries is needed since upload/download GHA is using zip compression
-        # and it can't preserve files permissions - https://github.com/actions/upload-artifact/issues/38
         chmod +x ./bin/*
-
         ./bin/oidnTest
         ./bin/oidnBenchmark -v 1
-
 
   build-cpu-ubuntu-2204:
     runs-on: ubuntu-latest
@@ -116,7 +111,6 @@ jobs:
         name: build-cpu-ubuntu-2204
         path: build/install
 
-
   test-cpu-ubuntu-2204:
     needs: build-cpu-ubuntu-2204
     runs-on: ubuntu-latest
@@ -131,9 +125,84 @@ jobs:
 
     - name: Test
       run: |
-        # Adding execution bit to binaries is needed since upload/download GHA is using zip compression
-        # and it can't preserve files permissions - https://github.com/actions/upload-artifact/issues/38
         chmod +x ./bin/*
-
         ./bin/oidnTest
         ./bin/oidnBenchmark -v 1
+
+  build-cpu-rocky-8-arm:
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: arm64v8/rockylinux:8
+
+    steps:
+    - name: Install packages
+      run: |
+        echo "Installing build dependencies..."
+        dnf update -y
+        dnf group install "Development Tools" -y
+        dnf install -y git-lfs cmake wget tbb-devel
+
+        mkdir /tmp/deps
+        cd /tmp/deps
+
+        wget https://github.com/ispc/ispc/releases/download/v1.24.0/ispc-v1.24.0-linux.tar.gz
+        tar -xvf ispc-v1.24.0-linux.tar.gz
+        echo "PATH=$PATH:`pwd`/ispc-v1.24.0-linux/bin" >> $GITHUB_ENV
+
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        lfs: true
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake -D CMAKE_INSTALL_PREFIX=`pwd`/install -D OIDN_INSTALL_DEPENDENCIES=ON -D OIDN_ZIP_MODE=ON ..
+        make -j$(nproc) install
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-cpu-rocky-8-arm
+        path: build/install
+
+  build-cpu-ubuntu-2204-arm:
+    runs-on: ubuntu-22.04-arm
+    container:
+      image: arm64v8/ubuntu:22.04
+
+    steps:
+    - name: Install packages
+      run: |
+        echo "Installing build dependencies..."
+        apt update
+        apt upgrade -y
+        apt install build-essential cmake git-lfs wget python3 libtbb2-dev -y
+
+        mkdir /tmp/deps
+        cd /tmp/deps
+
+        wget https://github.com/ispc/ispc/releases/download/v1.24.0/ispc-v1.24.0-linux.tar.gz
+        tar -xvf ispc-v1.24.0-linux.tar.gz
+        echo "PATH=$PATH:`pwd`/ispc-v1.24.0-linux/bin" >> $GITHUB_ENV
+
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        lfs: true
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake -D CMAKE_INSTALL_PREFIX=`pwd`/install -D OIDN_INSTALL_DEPENDENCIES=ON -D OIDN_ZIP_MODE=ON ..
+        make -j`nproc` install
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-cpu-ubuntu-2204-arm
+        path: build/install


### PR DESCRIPTION
This pull request includes several changes to the `.github/workflows/external.ci.yml` file to enhance the CI pipeline by adding support for ARM builds and cleaning up existing job definitions.

### Enhancements to CI pipeline:

* Added new build job `build-cpu-rocky-8-arm` to support ARM architecture using `arm64v8/rockylinux:8` container. This includes steps to install necessary packages, checkout the repository, build the project, and upload the build artifacts.
* Added new build job `build-cpu-ubuntu-2204-arm` to support ARM architecture using `arm64v8/ubuntu:22.04` container. This includes steps to install necessary packages, checkout the repository, build the project, and upload the build artifacts.

### Cleanup:

* Removed redundant comments related to file permission issues during artifact upload/download in the `test-cpu-rocky-8` and `test-cpu-ubuntu-2204` jobs. [[1]](diffhunk://#diff-a75dec5b56294e3cfc8263c4a9092d3c0bb7933ff797c3459cc51a7490bcf14aL72-L79) [[2]](diffhunk://#diff-a75dec5b56294e3cfc8263c4a9092d3c0bb7933ff797c3459cc51a7490bcf14aL134-R208)
* Removed unnecessary blank lines in the `test-cpu-rocky-8` and `test-cpu-ubuntu-2204` job definitions for better readability. [[1]](diffhunk://#diff-a75dec5b56294e3cfc8263c4a9092d3c0bb7933ff797c3459cc51a7490bcf14aL57) [[2]](diffhunk://#diff-a75dec5b56294e3cfc8263c4a9092d3c0bb7933ff797c3459cc51a7490bcf14aL119)