### PR TITLE
Support Blackwell GPUs with Cuda compute capability of 12.0 (=120)

### DIFF
--- a/devices/cuda/cuda_device.h
+++ b/devices/cuda/cuda_device.h
@@ -50,7 +50,7 @@ OIDN_NAMESPACE_BEGIN
 
     // Supported compute capabilities
     static constexpr int minSMArch = 70;
-    static constexpr int maxSMArch = 99;
+    static constexpr int maxSMArch = 129;
 
     int deviceID = 0;
   #if defined(OIDN_DEVICE_CUDA_API_DRIVER)


### PR DESCRIPTION
Hi!

Blackwell nvidia gpus bump cuda capability to 12.0. 

`const int smArch = prop.major * 10 + prop.minor;`

smArch here will get the value of 120

And the following check fails:
`if (smArch < minSMArch || smArch > maxSMArch)`

So I bumped the maxSMArch to 129. This ensures compatibility with all 12.X major versions.

I'm not sure of the intent here. if OIDN wants to support tested GPUs only, 129 seems appropriate. But if OIDN wants to support future GPUs by default, this could be set to 999.