### PR TITLE
HIP - add support of gfx1031-1036; gfx1150; gfx1151

### DIFF
--- a/devices/hip/CMakeLists.txt
+++ b/devices/hip/CMakeLists.txt
@@ -25,7 +25,7 @@ include(oidn_common_external)
 # FIXME: Older versions of the HIP runtime have a bug which may cause a crash if the kernels are
 # not compiled for all targets detected in the system (it seems mostly APUs/integrated GPUs).
 # As a workaround, we compile for more targets then we actually support to avoid this crash.
-set(GPU_TARGETS "gfx902,gfx909,gfx90c,gfx1030,gfx1031,gfx1032,gfx1033,gfx1034,gfx1035,gfx1036,gfx1100,gfx1101,gfx1102,gfx1103,gfx1200,gfx1201" CACHE INTERNAL "")
+set(GPU_TARGETS "gfx902,gfx909,gfx90c,gfx1030,gfx1031,gfx1032,gfx1033,gfx1034,gfx1035,gfx1036,gfx1100,gfx1101,gfx1102,gfx1103,gfx1150,gfx1151,gfx1200,gfx1201" CACHE INTERNAL "")
 set(AMDGPU_TARGETS ${GPU_TARGETS} CACHE INTERNAL "")
 
 # Find HIP

--- a/devices/hip/hip_device.cpp
+++ b/devices/hip/hip_device.cpp
@@ -99,7 +99,8 @@ OIDN_NAMESPACE_BEGIN
 
     if (name == "gfx1030")
       return HIPArch::DL;
-    if (name == "gfx1100" || name == "gfx1101" || name == "gfx1102" ||
+    if (name == "gfx1100" || name == "gfx1101" || name == "gfx1102" || name == "gfx1103" ||
+        name == "gfx1150" || name == "gfx1151" || name == "gfx1152" ||
         name == "gfx1200" || name == "gfx1201")
       return HIPArch::WMMA;
     else

--- a/devices/hip/hip_device.cpp
+++ b/devices/hip/hip_device.cpp
@@ -96,8 +96,8 @@ OIDN_NAMESPACE_BEGIN
   HIPArch HIPDevice::getArch(const hipDeviceProp_t& prop)
   {
     const std::string name = getArchName(prop);
-
-    if (name == "gfx1030")
+    if (name == "gfx1030" || name == "gfx1031" || name == "gfx1032" || name == "gfx1033" || 
+        name == "gfx1034" || name == "gfx1035" || name == "gfx1036")
       return HIPArch::DL;
     if (name == "gfx1100" || name == "gfx1101" || name == "gfx1102" || name == "gfx1103" ||
         name == "gfx1150" || name == "gfx1151" || name == "gfx1152" ||

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-torch==2.4.1
-tensorboard==2.18.0
+torch==2.7.0
+tensorboard==2.19.0


### PR DESCRIPTION
I took a more recent external/composable_kernel commit that introduced gfx115x support. 
( https://github.com/ROCm/composable_kernel/commit/3e6d21adeb33db1319899a3833113c9caf715358 )
I'm also adding gfx1103 ( Phoenix ) to hip_device.cpp